### PR TITLE
Tags+resource limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,22 @@ data:
   auth-token: ZjIzZjU0ZTIwODk5ZWYwYzgzYmJkMzZmYzU3ODlhNzc3ODJjYTY1YjJjODIzZTMyMjY3NDcxM2QzZTc3Mzg2Yw==
 ```
 
+#### [4.8] Configure deployment to support child pods to inherit labels from the crane
+- If user/admins require certain set of labels as part of the deployment of a cluster resource, we can use this `labels` values. These labels will be Inherited from the crane when the child pods are deployed. Because, note that labels added to crane deployment will not be automatically inherited by the child pods. Switch the use to `yes` and add labels in a Json format as per the example:
+```yaml
+labels:
+  use: yes 
+  labelsJson: {"label_1": "label_1_value", "label_2": "label2value"}
+```
+
+#### [4.8] Configure deployment to support child pods to inherit resource limits from the crane
+- If user/admins require a CPU, MEM limit to be applied to all cluster resources, we can use this `resourceLimit` values. These resource limits will be Inherited from the crane ENV when the child pods are deployed. Because, note that resource limit added to crane deployment will not be automatically inherited by the child pods. Switch the use to `yes` and add resource limits in a string format as per the example:
+```yaml
+resourceLimit:
+  use: yes
+  CPU: "800m"
+  MEM: "4Gi"
+```
 
 #### [5.0] Verify if everything is setup correctly
 - Once the values are updated, please verify if the values are correctly used in the helm chart:

--- a/templates/crane.yaml
+++ b/templates/crane.yaml
@@ -87,7 +87,7 @@ spec:
         {{ end }}
         {{- if .Values.labels.use }}
         - name: KUBERNETES_LABELS
-          value: {{ .Values.labels.labelsJson }}
+          value: {{ .Values.labels.labelsJson | toJson }}
         {{ end }}
         {{ if .Values.resourceLimit.use }}
         - name: KUBERNETES_RESOURCES_LIMITS_CPU

--- a/templates/crane.yaml
+++ b/templates/crane.yaml
@@ -85,10 +85,10 @@ spec:
         - name: INHERIT_RUNNING_USER_AND_GROUP
           value: 'true'
         {{ end }}
-        {{- if .Values.env.labels.use }}
+        {{- if .Values.labels.use }}
         - name: KUBERNETES_LABELS
-          value: {"label_1": "label_1_value", "label_2": "label_2_value"}
-        {{ end -}}
+          value: {{ .Values.labels.labelsJson }}
+        {{ end }}
         image: {{ .Values.env.image }}
         imagePullPolicy: {{ .Values.env.pullPolicy }}
         name: crane-container

--- a/templates/crane.yaml
+++ b/templates/crane.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     role: {{ .Values.matches.role }}
-  name: {{ .Release.name }}crane
+  name: {{ .Values.deployment.name }}
   namespace: {{ .Values.deployment.namespace }}
 spec:
   replicas: 1
@@ -87,7 +87,7 @@ spec:
         {{ end }}
         {{- if .Values.labels.use }}
         - name: KUBERNETES_LABELS
-          value: {{ .Values.labels.labelsJson | toJson }}
+          value: {{ .Values.labels.labelsJson | toJson | quote}}
         {{ end }}
         {{ if .Values.resourceLimit.use }}
         - name: KUBERNETES_RESOURCES_LIMITS_CPU

--- a/templates/crane.yaml
+++ b/templates/crane.yaml
@@ -88,13 +88,13 @@ spec:
         {{- if .Values.labels.use }}
         - name: KUBERNETES_LABELS
           value: {{ .Values.labels.labelsJson | toJson | quote}}
-        {{ end }}
+        {{ end -}}
         {{ if .Values.resourceLimit.use }}
         - name: KUBERNETES_RESOURCES_LIMITS_CPU
           value: {{ .Values.resourceLimit.CPU | quote }}
         - name: KUBERNETES_RESOURCES_LIMITS_MEMORY
           value: {{ .Values.resourceLimit.MEM | quote }}
-        {{ end }}
+        {{ end -}}
         image: {{ .Values.env.image }}
         imagePullPolicy: {{ .Values.env.pullPolicy }}
         name: crane-container

--- a/templates/crane.yaml
+++ b/templates/crane.yaml
@@ -89,6 +89,12 @@ spec:
         - name: KUBERNETES_LABELS
           value: {{ .Values.labels.labelsJson }}
         {{ end }}
+        {{ if .Values.resourceLimit.use }}
+        - name: KUBERNETES_RESOURCES_LIMITS_CPU
+          value: {{ .Values.resourceLimit.CPU | quote }}
+        - name: KUBERNETES_RESOURCES_LIMITS_MEMORY
+          value: {{ .Values.resourceLimit.MEM | quote }}
+        {{ end }}
         image: {{ .Values.env.image }}
         imagePullPolicy: {{ .Values.env.pullPolicy }}
         name: crane-container

--- a/templates/crane.yaml
+++ b/templates/crane.yaml
@@ -85,6 +85,10 @@ spec:
         - name: INHERIT_RUNNING_USER_AND_GROUP
           value: 'true'
         {{ end }}
+        {{- if .Values.env.labels.use }}
+        - name: KUBERNETES_LABELS
+          value: {"label_1": "label_1_value", "label_2": "label_2_value"}
+        {{ end -}}
         image: {{ .Values.env.image }}
         imagePullPolicy: {{ .Values.env.pullPolicy }}
         name: crane-container

--- a/values.yaml
+++ b/values.yaml
@@ -72,6 +72,7 @@ istio_ingress:
   pre_pulling: "true" 
   istio_gateway_name: "bzm-gateway"
 
+
 # Labels to add to resources created by Crane
 labels:
   use: yes 
@@ -80,6 +81,6 @@ labels:
 # CPU limits for resources created by agent.
 # Memory limits for resources created by agent.
 resourceLimit:
-  use: yes 
-  CPU: "2"
-  MEM: "8"
+  use: yes
+  CPU: "800m"
+  MEM: "4Gi"

--- a/values.yaml
+++ b/values.yaml
@@ -72,3 +72,7 @@ istio_ingress:
   pre_pulling: "true" 
   istio_gateway_name: "bzm-gateway"
 
+# Labels to add to resources created by Crane
+labels:
+  use: no 
+  labelsJson: {"label_1": "label_1_value", "label_2": "label"}

--- a/values.yaml
+++ b/values.yaml
@@ -76,3 +76,10 @@ istio_ingress:
 labels:
   use: no 
   labelsJson: {"label_1": "label_1_value", "label_2": "label"}
+
+# CPU limits for resources created by agent.
+# Memory limits for resources created by agent.
+resourceLimit:
+  use: no 
+  CPU: "2"
+  MEM: "8"

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,7 @@
 
 deployment:
   name: crane
-  namespace: "bm1"
+  namespace: "bm"
 
 matches:
   crane: "ready"
@@ -18,7 +18,7 @@ env:
   authToken: 
     # if you want to pass the AUTH_TOKEN through secret in the crane ENV variables set secret to yes and add secret name and key
     secret:
-      use: yes
+      use: no
       secretName: "your-secretName"
       secretKey: "auth-token"
     # if secret is not used, please enter the AUTH_TOKEN below directly. 
@@ -74,12 +74,12 @@ istio_ingress:
 
 # Labels to add to resources created by Crane
 labels:
-  use: no 
-  labelsJson: {"label_1": "label_1_value", "label_2": "label"}
+  use: yes 
+  labelsJson: {"label_1": "label_1_value", "label_2": "label2value"}
 
 # CPU limits for resources created by agent.
 # Memory limits for resources created by agent.
 resourceLimit:
-  use: no 
+  use: yes 
   CPU: "2"
   MEM: "8"

--- a/values.yaml
+++ b/values.yaml
@@ -3,6 +3,7 @@ deployment:
   name: crane
   namespace: "bm"
 
+# This is the name of roles and clusterroles created by the chart.
 matches:
   crane: "ready"
   role: "roleCrane"
@@ -75,12 +76,12 @@ istio_ingress:
 
 # Labels to add to resources created by Crane
 labels:
-  use: yes 
+  use: no 
   labelsJson: {"label_1": "label_1_value", "label_2": "label2value"}
 
 # CPU limits for resources created by agent.
 # Memory limits for resources created by agent.
 resourceLimit:
-  use: yes
+  use: no
   CPU: "800m"
   MEM: "4Gi"


### PR DESCRIPTION
Added support for adding labels and resource limits that can be now inherited to child pods from crane env variables. 
This is important because many clusters have a security requirement of having a resource limit and a set of labels to be able to set cluster policies. 