### PR TITLE
Nginx ingress

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -1,0 +1,4 @@
+*.png
+.git
+*.md
+.gitignore

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: blazemeter-crane
+name: helm-crane
 description: A Helm chart for Blazemeter crane private location engine deployment.
 keywords:
   - crane

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -19,6 +19,7 @@ keywords:
   - Secret
   - Labels
   - ResourceLimit
+  - Nginx Ingress
 
 type: application
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -22,7 +22,11 @@ keywords:
 
 type: application
 
-version: 1.1.0
+#dependencies:
+# - name: nginx
+#    condition: .Values.installed
+
+version: 1.2.0
 
 maintainers: 
   - name: Manan Patel

--- a/templates/bzm-gateway.yaml
+++ b/templates/bzm-gateway.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.istio_ingress.use }}
+{{ if and (.Values.istio_ingress.use)  (eq .Values.nginx_ingress.use false) }} 
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:

--- a/templates/bzm-gateway.yaml
+++ b/templates/bzm-gateway.yaml
@@ -1,4 +1,4 @@
-{{ if and (.Values.istio_ingress.use)  (eq .Values.nginx_ingress.use false) }} 
+{{ if and (.Values.istio_ingress.enable)  (eq .Values.nginx_ingress.enable false) }} 
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:

--- a/templates/crane.yaml
+++ b/templates/crane.yaml
@@ -65,7 +65,7 @@ spec:
         - name: KUBERNETES_CA_BUNDLE_MOUNT
           value: REQUESTS_CA_BUNDLE={{ .Release.Name }}-configmap=certificate.crt:AWS_CA_BUNDLE={{ .Release.Name }}-configmap=certificate.crt
         {{- end -}}
-        {{ if .Values.istio_ingress.use }}
+        {{ if and (.Values.istio_ingress.use)  (eq .Values.nginx_ingress.use false) }}
         - name: KUBERNETES_WEB_EXPOSE_TYPE
           value: ISTIO
         - name: KUBERNETES_WEB_EXPOSE_SUB_DOMAIN
@@ -80,6 +80,24 @@ spec:
           value: "true"
         - name: KUBERNETES_ISTIO_GATEWAY_NAME
           value: {{ .Values.istio_ingress.istio_gateway_name | quote }}
+        {{- end -}}
+        {{ if and (.Values.nginx_ingress.use)  (eq .Values.istio_ingress.use false)}}
+        - name: KUBERNETES_WEB_EXPOSE_TYPE
+          value: INGRESS
+        - name: KUBERNETES_INGRESS_CLASS
+          value: "nginx"
+        - name: KUBERNETES_SERVICE_USE_TYPE
+          value: CLUSTERIP
+        - name: KUBERNETES_WEB_EXPOSE_SUB_DOMAIN
+          value: {{ .Values.nginx_ingress.web_expose_subdomain | quote }}
+        - name: KUBERNETES_WEB_EXPOSE_TLS_SECRET_NAME
+          value: {{ .Values.nginx_ingress.credentialName | quote }}
+        - name: PARALLEL_HANDLERS_COUNT
+          value: '50'
+        - name: USE_PARALLEL_HANDLER
+          value: 'true'
+        - name: RUN_HEALTH_WEB_SERVICE
+          value: 'true'
         {{- end -}}
         {{ if .Values.non_privilege_container.use }}
         - name: INHERIT_RUNNING_USER_AND_GROUP

--- a/templates/crane.yaml
+++ b/templates/crane.yaml
@@ -23,7 +23,7 @@ spec:
       automountServiceAccountToken: true
       containers:
       - env:
-      {{ if .Values.env.authToken.secret.use }}
+      {{ if .Values.env.authToken.secret.enable }}
         - name: AUTH_TOKEN
           valueFrom:
             secretKeyRef:
@@ -45,7 +45,7 @@ spec:
           value: {{ .Values.env.docker_regirstry }}
         - name: AUTO_KUBERNETES_UPDATE
           value: {{ .Values.env.auto_update }}
-        {{- if .Values.proxy.use -}}
+        {{- if .Values.proxy.enable -}}
           {{ if .Values.proxy.http_proxy }}
         - name: HTTP_PROXY
           value: {{ .Values.proxy.http_path }}
@@ -57,7 +57,7 @@ spec:
         - name: NO_PROXY
           value: {{ .Values.proxy.no_proxy }}
         {{- end -}}
-        {{ if .Values.ca_bundle.use }}
+        {{ if .Values.ca_bundle.enable }}
         - name: REQUEST_CA_BUNDLE
           value: {{ .Values.volume.mount_path }}/{{ .Values.ca_bundle.ca_subpath }}
         - name: AWS_CA_BUNDLE
@@ -65,28 +65,28 @@ spec:
         - name: KUBERNETES_CA_BUNDLE_MOUNT
           value: REQUESTS_CA_BUNDLE={{ .Release.Name }}-configmap=certificate.crt:AWS_CA_BUNDLE={{ .Release.Name }}-configmap=certificate.crt
         {{- end -}}
-        {{ if and (.Values.istio_ingress.use)  (eq .Values.nginx_ingress.use false) }}
+        {{ if and (.Values.istio_ingress.enable)  (eq .Values.nginx_ingress.enable false) }}
         - name: KUBERNETES_WEB_EXPOSE_TYPE
           value: ISTIO
         - name: KUBERNETES_WEB_EXPOSE_SUB_DOMAIN
           value: {{ .Values.istio_ingress.web_expose_subdomain | quote }}
         - name: KUBERNETES_WEB_EXPOSE_TLS_SECRET_NAME
           value: {{ .Values.istio_ingress.credentialName | quote }}
-        - name: KUBERNETES_SERVICE_USE_TYPE
+        - name: KUBERNETES_SERVICE_enable_TYPE
           value: CLUSTERIP
-        - name: KUBERNETES_USE_PRE_PULLING
+        - name: KUBERNETES_enable_PRE_PULLING
           value: {{ .Values.istio_ingress.pre_pulling | quote }}
         - name: KUBERNETES_SERVICES_BLOCKING_GET
           value: "true"
         - name: KUBERNETES_ISTIO_GATEWAY_NAME
           value: {{ .Values.istio_ingress.istio_gateway_name | quote }}
         {{- end -}}
-        {{ if and (.Values.nginx_ingress.use)  (eq .Values.istio_ingress.use false)}}
+        {{ if and (.Values.nginx_ingress.enable)  (eq .Values.istio_ingress.enable false)}}
         - name: KUBERNETES_WEB_EXPOSE_TYPE
           value: INGRESS
         - name: KUBERNETES_INGRESS_CLASS
           value: "nginx"
-        - name: KUBERNETES_SERVICE_USE_TYPE
+        - name: KUBERNETES_SERVICE_enable_TYPE
           value: CLUSTERIP
         - name: KUBERNETES_WEB_EXPOSE_SUB_DOMAIN
           value: {{ .Values.nginx_ingress.web_expose_subdomain | quote }}
@@ -94,20 +94,20 @@ spec:
           value: {{ .Values.nginx_ingress.credentialName | quote }}
         - name: PARALLEL_HANDLERS_COUNT
           value: '50'
-        - name: USE_PARALLEL_HANDLER
+        - name: enable_PARALLEL_HANDLER
           value: 'true'
         - name: RUN_HEALTH_WEB_SERVICE
           value: 'true'
         {{- end -}}
-        {{ if .Values.non_privilege_container.use }}
-        - name: INHERIT_RUNNING_USER_AND_GROUP
+        {{ if .Values.non_privilege_container.enable }}
+        - name: INHERIT_RUNNING_enableR_AND_GROUP
           value: 'true'
         {{ end }}
-        {{- if .Values.labels.use }}
+        {{- if .Values.labels.enable }}
         - name: KUBERNETES_LABELS
           value: {{ .Values.labels.labelsJson | toJson | quote}}
         {{ end }}
-        {{ if .Values.resourceLimit.use }}
+        {{ if .Values.resourceLimit.enable }}
         - name: KUBERNETES_RESOURCES_LIMITS_CPU
           value: {{ .Values.resourceLimit.CPU | quote }}
         - name: KUBERNETES_RESOURCES_LIMITS_MEMORY
@@ -116,7 +116,7 @@ spec:
         image: {{ .Values.env.image }}
         imagePullPolicy: {{ .Values.env.pullPolicy }}
         name: crane-container
-        {{ if .Values.ca_bundle.use }}
+        {{ if .Values.ca_bundle.enable }}
         volumeMounts:
         - name: {{ .Values.volume.volume_name }}
           mountPath: {{ .Values.volume.mount_path }}
@@ -125,14 +125,14 @@ spec:
         configMap:
           name: {{ .Release.Name }}-configmap
         {{ end }}   
-      {{- if .Values.non_privilege_container.use }}
+      {{- if .Values.non_privilege_container.enable }}
       securityContext:
         allowPrivilegeEscalation: false
         capabilities:
           drop:
           - ALL
         runAsGroup: {{ .Values.non_privilege_container.runAsGroup }}   
-        runAsUser: {{ .Values.non_privilege_container.runAsUser }}        
+        runAsenabler: {{ .Values.non_privilege_container.runAsenabler }}        
       {{ end }}
       restartPolicy: {{ .Values.restartPolicy }}
       terminationGracePeriodSeconds: 30

--- a/templates/crane.yaml
+++ b/templates/crane.yaml
@@ -132,7 +132,7 @@ spec:
           drop:
           - ALL
         runAsGroup: {{ .Values.non_privilege_container.runAsGroup }}   
-        runAsenabler: {{ .Values.non_privilege_container.runAsenabler }}        
+        runAsUser: {{ .Values.non_privilege_container.runAsUser }}        
       {{ end }}
       restartPolicy: {{ .Values.restartPolicy }}
       terminationGracePeriodSeconds: 30

--- a/templates/crane.yaml
+++ b/templates/crane.yaml
@@ -72,9 +72,9 @@ spec:
           value: {{ .Values.istio_ingress.web_expose_subdomain | quote }}
         - name: KUBERNETES_WEB_EXPOSE_TLS_SECRET_NAME
           value: {{ .Values.istio_ingress.credentialName | quote }}
-        - name: KUBERNETES_SERVICE_enable_TYPE
+        - name: KUBERNETES_SERVICE_USE_TYPE
           value: CLUSTERIP
-        - name: KUBERNETES_enable_PRE_PULLING
+        - name: KUBERNETES_USE_PRE_PULLING
           value: {{ .Values.istio_ingress.pre_pulling | quote }}
         - name: KUBERNETES_SERVICES_BLOCKING_GET
           value: "true"
@@ -86,7 +86,7 @@ spec:
           value: INGRESS
         - name: KUBERNETES_INGRESS_CLASS
           value: "nginx"
-        - name: KUBERNETES_SERVICE_enable_TYPE
+        - name: KUBERNETES_SERVICE_USE_TYPE
           value: CLUSTERIP
         - name: KUBERNETES_WEB_EXPOSE_SUB_DOMAIN
           value: {{ .Values.nginx_ingress.web_expose_subdomain | quote }}
@@ -94,13 +94,13 @@ spec:
           value: {{ .Values.nginx_ingress.credentialName | quote }}
         - name: PARALLEL_HANDLERS_COUNT
           value: '50'
-        - name: enable_PARALLEL_HANDLER
+        - name: USE_PARALLEL_HANDLER
           value: 'true'
         - name: RUN_HEALTH_WEB_SERVICE
           value: 'true'
         {{- end -}}
         {{ if .Values.non_privilege_container.enable }}
-        - name: INHERIT_RUNNING_enableR_AND_GROUP
+        - name: INHERIT_RUNNING_USER_AND_GROUP
           value: 'true'
         {{ end }}
         {{- if .Values.labels.enable }}

--- a/templates/rbac-ns.yaml
+++ b/templates/rbac-ns.yaml
@@ -14,12 +14,13 @@ rules:
   resources: ["pods", "services", "endpoints", "daemonsets", "pods/*", "pods/exec", "deployments", "replicasets", "ingresses", "deployments/scale", "jobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection", "createcollection"]
 {{ if and (.Values.istio_ingress.use)  (eq .Values.nginx_ingress.use false) }} 
-# this is for istio ingress for mock services
+# this is for istio ingress mock services deployment
 - apiGroups: ["networking.istio.io"]
   resources: ["destinationrules", "virtualservices", "gateways"]
   verbs: ["get", "list", "create", "delete", "patch", "update"]
-{{ end }}
+{{- end -}}
 {{ if and (.Values.nginx_ingress.use)  (eq .Values.istio_ingress.use false)}}
+# this is for nginx ingress mock services deployment
 - apiGroups: ["networking.k8s.io"]
   resources: ["virtualservices", "gateways", "ingresses"]
   verbs: ["get", "list", "create", "delete", "patch", "update"]

--- a/templates/rbac-ns.yaml
+++ b/templates/rbac-ns.yaml
@@ -13,13 +13,13 @@ rules:
 - apiGroups: ["extensions", "apps", "batch", ""] # leave empty string for core
   resources: ["pods", "services", "endpoints", "daemonsets", "pods/*", "pods/exec", "deployments", "replicasets", "ingresses", "deployments/scale", "jobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection", "createcollection"]
-{{ if and (.Values.istio_ingress.use)  (eq .Values.nginx_ingress.use false) }} 
+{{ if and (.Values.istio_ingress.enable)  (eq .Values.nginx_ingress.enable false) }} 
 # this is for istio ingress mock services deployment
 - apiGroups: ["networking.istio.io"]
   resources: ["destinationrules", "virtualservices", "gateways"]
   verbs: ["get", "list", "create", "delete", "patch", "update"]
 {{- end -}}
-{{ if and (.Values.nginx_ingress.use)  (eq .Values.istio_ingress.use false)}}
+{{ if and (.Values.nginx_ingress.enable)  (eq .Values.istio_ingress.enable false)}}
 # this is for nginx ingress mock services deployment
 - apiGroups: ["networking.k8s.io"]
   resources: ["virtualservices", "gateways", "ingresses"]

--- a/templates/rbac-ns.yaml
+++ b/templates/rbac-ns.yaml
@@ -10,15 +10,21 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "pods/log"]
   verbs: ["get", "list"]
-- apiGroups: ["extensions", "apps", ""] # leave empty string for core
-  resources: ["pods", "services", "endpoints", "daemonsets", "pods/*", "pods/exec", "deployments", "replicasets", "ingresses", "deployments/scale"]
+- apiGroups: ["extensions", "apps", "batch", ""] # leave empty string for core
+  resources: ["pods", "services", "endpoints", "daemonsets", "pods/*", "pods/exec", "deployments", "replicasets", "ingresses", "deployments/scale", "jobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection", "createcollection"]
-{{ if .Values.istio_ingress.use }} 
+{{ if and (.Values.istio_ingress.use)  (eq .Values.nginx_ingress.use false) }} 
 # this is for istio ingress for mock services
 - apiGroups: ["networking.istio.io"]
   resources: ["destinationrules", "virtualservices", "gateways"]
   verbs: ["get", "list", "create", "delete", "patch", "update"]
 {{ end }}
+{{ if and (.Values.nginx_ingress.use)  (eq .Values.istio_ingress.use false)}}
+- apiGroups: ["networking.k8s.io"]
+  resources: ["virtualservices", "gateways", "ingresses"]
+  verbs: ["get", "list", "create", "delete", "patch", "update"]
+{{ end }}
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/values.yaml
+++ b/values.yaml
@@ -73,10 +73,11 @@ istio_ingress:
   pre_pulling: "true" 
   istio_gateway_name: "bzm-gateway"
 
-# We can enable nginx-ingress instead of istio-ingress
+# We can enable nginx-ingress instead of istio-ingress, currently, the chart expects nginx-ingress to be pre-installed in the cluster. 
+# Follow Blazemeter guide for more information on installing nginx-ingress.
 nginx_ingress:
-  enable: no
-  pre-installed: no # if you have nginx-ingress installed in your cluster, set this to true
+  enable: yes
+#  pre-installed: yes
   credentialName: "wildcard-credential"
   web_expose_subdomain: "mydomain.local"  
 

--- a/values.yaml
+++ b/values.yaml
@@ -34,7 +34,7 @@ env:
   # Proxy configurations here, change enable to yes, followed by http/https configuration
 proxy:
   enable: no
- # If you have authentication required for your proxy, then you will need to add enablername:password@server:port
+ # If you have authentication required for your proxy, then you will need to add username:password@server:port
   http_proxy: yes
   http_path: "http://server:port" 
 
@@ -58,7 +58,7 @@ volume:
 non_privilege_container:
   enable: no
   runAsGroup: 1337
-  runAsenabler: 1337
+  runAsUser: 1337
 
 restartPolicy: "Always"
 

--- a/values.yaml
+++ b/values.yaml
@@ -12,17 +12,17 @@ matches:
 serviceAccount:
   # Specifies whether a ServiceAccount should be created, currently BM OPLs in Kubernetes only supports default service account.
   create: false
-  # The name of the ServiceAccount to use, keep empty to use default account.
+  # The name of the ServiceAccount to enable, keep empty to enable default account.
   name: 
 
 env:
   authToken: 
     # if you want to pass the AUTH_TOKEN through secret in the crane ENV variables set secret to yes and add secret name and key
     secret:
-      use: no
+      enable: no
       secretName: "your-secretName"
       secretKey: "auth-token"
-    # if secret is not used, please enter the AUTH_TOKEN below directly. 
+    # if secret is not enabled, please enter the AUTH_TOKEN below directly. 
     token:  "MY_SAMPLE_TOKEN-shfowh243owijoidh243o2nosIOIJONo2414"
   harbour_id: "MY_SAMPLE_HARBOURID-302870vdr9237"
   ship_id: "MY_SAMPLE_SHIPID-dfwe3423535"
@@ -31,63 +31,63 @@ env:
   image: "gcr.io/verdant-bulwark-278/blazemeter/crane:latest-master"
   pullPolicy: "Always"
 
-  # Proxy configurations here, change use to yes, followed by http/https configuration
+  # Proxy configurations here, change enable to yes, followed by http/https configuration
 proxy:
-  use: no
- # If you have authentication required for your proxy, then you will need to add username:password@server:port
+  enable: no
+ # If you have authentication required for your proxy, then you will need to add enablername:password@server:port
   http_proxy: yes
   http_path: "http://server:port" 
 
   https_proxy: yes
   https_path: "https://server:port"  
 #  The NO_PROXY settings for 127.0.0.1 and localhost (provided below) are required for the Service Virtualization integration and 
-#  Transaction-based Mock Services to work. If you do not use any HTTP_PROXY or HTTPS_PROXY settings, you can skip the NO_PROXY setting.
+#  Transaction-based Mock Services to work. If you do not enable any HTTP_PROXY or HTTPS_PROXY settings, you can skip the NO_PROXY setting.
   no_proxy: "kubernetes.default,127.0.0.1,localhost,myHostname.com"
 
-# Configure CA Bundle here - Change use: yes
+# Configure CA Bundle here - Change enable: yes
 ca_bundle:
-  use: no
+  enable: no
   ca_subpath: "certificate.crt"
   aws_subpath: "certificate.crt"
 volume:
   volume_name: "volume-cm"
   mount_path: "/var/cm"
 
-# If you plan to use non-privileged containers, please enable the below configuration, change use:yes
+# If you plan to enable non-privileged containers, please enable the below configuration, change enable:yes
 # This will run all pods/containers (related to private location installation) within the cluster as non_root.
 non_privilege_container:
-  use: no
+  enable: no
   runAsGroup: 1337
-  runAsUser: 1337
+  runAsenabler: 1337
 
 restartPolicy: "Always"
 
-# Use Istio-Ingress if this Private location is going to run mock-services
+# enable Istio-Ingress if this Private location is going to run mock-services
 # Follow this guide till you have created a secret in istio-system namespace called wildcard-credential.
 # https://guide.blazemeter.com/hc/en-us/articles/20206158935953-Installing-a-BlazeMeter-Agent-for-Kubernetes-Mock-Services#h_01F68B8GZSBKE9A9G7TMK105F7
 
 istio_ingress: 
-  use: no
+  enable: no
   credentialName: "wildcard-credential"
   web_expose_subdomain: "mydomain.local"
   pre_pulling: "true" 
   istio_gateway_name: "bzm-gateway"
 
-# We can use nginx-ingress instead of istio-ingress
+# We can enable nginx-ingress instead of istio-ingress
 nginx_ingress:
-  use: no
+  enable: no
   pre-installed: no # if you have nginx-ingress installed in your cluster, set this to true
   credentialName: "wildcard-credential"
   web_expose_subdomain: "mydomain.local"  
 
 # Labels to add to resources created by Crane
 labels:
-  use: no 
+  enable: no 
   labelsJson: {"label_1": "label_1_value", "label_2": "label2value"}
 
 # CPU limits for resources created by agent.
 # Memory limits for resources created by agent.
 resourceLimit:
-  use: no
+  enable: no
   CPU: "800m"
   MEM: "4Gi"

--- a/values.yaml
+++ b/values.yaml
@@ -76,7 +76,7 @@ istio_ingress:
 # We can enable nginx-ingress instead of istio-ingress, currently, the chart expects nginx-ingress to be pre-installed in the cluster. 
 # Follow Blazemeter guide for more information on installing nginx-ingress.
 nginx_ingress:
-  enable: yes
+  enable: no
 #  pre-installed: yes
   credentialName: "wildcard-credential"
   web_expose_subdomain: "mydomain.local"  

--- a/values.yaml
+++ b/values.yaml
@@ -73,6 +73,12 @@ istio_ingress:
   pre_pulling: "true" 
   istio_gateway_name: "bzm-gateway"
 
+# We can use nginx-ingress instead of istio-ingress
+nginx_ingress:
+  use: no
+  pre-installed: no # if you have nginx-ingress installed in your cluster, set this to true
+  credentialName: "wildcard-credential"
+  web_expose_subdomain: "mydomain.local"  
 
 # Labels to add to resources created by Crane
 labels:


### PR DESCRIPTION
To summarise the changes:

1. The chart will not support Nginx ingress type deployment with crane for service-virtualisation
2. Fixed the role, so the crane logs will not report a 'batch' forbiddent error for 'jobs'. 
3. Ranamed the chart to 'helm-crane' 
4. Standardized the values usage keys, now says 'enable' (previously 'use')
5. Fixed the non-root type deployment issues.
6. Other Minor fixes 
