### PR TITLE
1.4.3 security context addition

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -38,7 +38,7 @@ icon: https://github.com/Blazemeter/helm-crane/raw/main/logo.png
 # - name: nginx
 #    condition: .Values.installed
 
-version: 1.4.2
+version: 1.4.3
 
 maintainers: 
   - name: Manan Patel

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ non_privilege_container:
 ```
 **Note:**  
 >- Non-root deployment requires an additional feature to be enabled at account level, please contact support for enabling this feature.*
-
+>- This will automatically configure the `securityContext.Capabilities` to `drop all` for crane and child resources.*
 
 
 ### [4.8] Configure deployment to support Service Virtualisation (Mock Services)

--- a/README.md
+++ b/README.md
@@ -725,9 +725,10 @@ helm uninstall <release-name> -n <namespace name>
 
 ## [10.0] Changelog:
 
-- 1.4.2 - Support for custom annotations with Crane and child resources.  
-- 1.4.1 - Added default values for secret wildcard credential for test-hook. Fixed minor condition handling for istio-based test-hook role configuration. No changes to main chart functionality.
-- 1.4.0 - Added support for Pod Disruption Budgets (PDB) and SecretProviderClass integration. Introduced ExternalSecrets Operator support. Addition of testHook for faster/accurate validation of installation. Simplified the image override usage. Incorporation of ingress setup & usage in one single config. Other minor bug fixes and template enhancements. Extended documentations on chart usage. 
-- 1.3.1 - Readiness and Liveness probes are now added. 
-- 1.3.0 - Chart can support image-override configuration. gridProxy is in working configuration. Resource (CPU & MEM) limit/requests are now configurable for crane and child resources and also for ephemeral storage. Simplified nesting and values configuration. The chart can now work with non-default serviceAccount. Tolerations, nodeSelector and labels can be declared for Crane and child resources separately, with Major fixes & calibrations.
+- 1.4.3: Inclusion of `securityContext.Capabilities` which would default to `drop: ["ALL"]` in our chart for child resources/executors. (No change to the values YAML file)
+- 1.4.2: Support for custom annotations with Crane and child resources.  
+- 1.4.1: Added default values for secret wildcard credential for test-hook. Fixed minor condition handling for istio-based test-hook role configuration. No changes to main chart functionality.
+- 1.4.0: Added support for Pod Disruption Budgets (PDB) and SecretProviderClass integration. Introduced ExternalSecrets Operator support. Addition of testHook for faster/accurate validation of installation. Simplified the image override usage. Incorporation of ingress setup & usage in one single config. Other minor bug fixes and template enhancements. Extended documentations on chart usage. 
+- 1.3.1: Readiness and Liveness probes are now added. 
+- 1.3.0: Chart can support image-override configuration. gridProxy is in working configuration. Resource (CPU & MEM) limit/requests are now configurable for crane and child resources and also for ephemeral storage. Simplified nesting and values configuration. The chart can now work with non-default serviceAccount. Tolerations, nodeSelector and labels can be declared for Crane and child resources separately, with Major fixes & calibrations.
 - **Anything below 1.3.0 - UNSUPPORTED**

--- a/templates/crane.yaml
+++ b/templates/crane.yaml
@@ -144,6 +144,8 @@ spec:
         {{ if .Values.non_privilege_container.enable | default false }}
         - name: INHERIT_RUNNING_USER_AND_GROUP
           value: 'true'
+        - name: KUBERNETES_SECURITY_CONTEXT_CAP_JSON
+          value: '{"drop": ["ALL"]}'
         {{ end -}}
         {{ if .Values.labelsExecutors.enable | default false }}
         - name: KUBERNETES_LABELS


### PR DESCRIPTION
This pull request updates the Helm chart to version 1.4.3 and introduces a security enhancement by defaulting the `securityContext.Capabilities` to drop all capabilities for crane and its child resources. Documentation has also been updated to reflect this change and clarify non-root deployment requirements.

**Security Enhancements:**
* Added the environment variable `KUBERNETES_SECURITY_CONTEXT_CAP_JSON` with value `{"drop": ["ALL"]}` to the `crane.yaml` template, ensuring that all Linux capabilities are dropped by default for crane and child resources.
* Updated the documentation to note that non-root deployment will automatically configure `securityContext.Capabilities` to `drop all` for crane and child resources.

**Versioning and Documentation:**
* Bumped chart version to `1.4.3` in `Chart.yaml`.
* Updated the changelog in `README.md` to document the inclusion of `securityContext.Capabilities` defaulting to `drop: ["ALL"]` for child resources/executors.