### PR TITLE
Fix ServiceAccount Label Generation for Empty Role Values

### DIFF
--- a/templates/serviceAccount.yaml
+++ b/templates/serviceAccount.yaml
@@ -13,4 +13,11 @@ metadata:
   labels:
     role: {{ include "crane.roleName" . }}
     clusterrole: {{ include "crane.clusterroleName" . }}
+<<<<<<< Updated upstream
 {{ end }}
+=======
+    {{ if .Values.labelsCrane.enable | default false -}}
+    {{ .Values.labelsCrane.syntax | toYaml | nindent 4 -}}
+    {{ end -}}
+{{ end }}
+>>>>>>> Stashed changes

--- a/templates/serviceAccount.yaml
+++ b/templates/serviceAccount.yaml
@@ -11,6 +11,6 @@ metadata:
     {{- end }}
   {{ end }}
   labels:
-    role: {{ .Release.Name }}-{{ .Values.deployment.role }}
-    clusterrole: {{ .Release.Name }}-{{ .Values.deployment.clusterrole }}
+    role: {{ include "crane.roleName" . }}
+    clusterrole: {{ include "crane.clusterroleName" . }}
 {{ end }}


### PR DESCRIPTION
When deployment.role and deployment.clusterrole are left empty in the values file, the Helm chart correctly creates new Role and ClusterRole resources with proper names (e.g., release-name-role). However, the ServiceAccount creation fails with a Kubernetes validation error due to invalid label values ending with dashes.